### PR TITLE
Tweak presentation of banner

### DIFF
--- a/jaraco/tidelift/banner.html
+++ b/jaraco/tidelift/banner.html
@@ -1,24 +1,29 @@
-<div class="tidelift for-enterprise" style="margin: 0 auto; width: 940px;">
-	<h3 class="donation" style="font-size: 2em; font-weight: normal;">For Enterprise</h3>
+<div class="tidelift for-enterprise" style="margin: 0 auto; width: 100%; max-width: 940px;">
+	<h2 class="donation">For Enterprise</h2>
 
-	<div style="float: left; padding-right: 10px;">
+	<div style="float: left; padding-right: 1rem">
 		<a href="https://tidelift.com/subscription/pkg/pypi-{{ project }}?utm_source=pypi-{{ project }}&utm_medium=referral&utm_campaign=docs">
 				<img alt="Tidelift" src="https://nedbatchelder.com/pix/Tidelift_Logos_RGB_Tidelift_Shorthand_On-White_small.png" style="height: 6rem">
 		</a>
 	</div>
 
-	<p style="text-align: justify">
+	<p>
 		Professional support for {{ project }} is available as part of the
-		<a class="reference external" href="https://tidelift.com/subscription/pkg/pypi-{{ project }}?utm_source=pypi-{{ project }}&utm_medium=referral&utm_campaign=docs">Tidelift
-Subscription</a>.
+		<a class="reference external" href="https://tidelift.com/subscription/pkg/pypi-{{ project }}?utm_source=pypi-{{ project }}&utm_medium=referral&utm_campaign=docs"
+		>Tidelift Subscription</a>.
 		Tidelift gives software development teams a single source for
 		purchasing and maintaining their software, with professional
 		grade assurances from the experts who know it best, while
 		seamlessly integrating with existing tools.
 	</p>
-
 	<p>
-		<a style="background-color: rgb(246, 145, 77); border-radius: 5px; color: white; display: inline-block; font-family: sans; font-size: 1.2rem; font-weight: bolder; margin: 5px; padding: 15px 0; text-align: center; text-decoration: none; text-transform: uppercase; width: 40%;" href="https://tidelift.com/subscription/pkg/pypi-{{ project }}?utm_source=pypi-{{ project }}&utm_medium=referral&utm_campaign=docs">Learn more</a>
-		<a style="background-color: rgb(246, 145, 77); border-radius: 5px; color: white; display: inline-block; font-family: sans; font-size: 1.2rem; font-weight: bolder; margin: 5px; padding: 15px 0; text-align: center; text-decoration: none; text-transform: uppercase; width: 41%;" href="https://tidelift.com/subscription/request-a-demo?utm_source=pypi-{{ project }}&utm_medium=referral&utm_campaign=docs">Request a Demo</a>
+		<a
+			href="https://tidelift.com/subscription/pkg/pypi-{{ project }}?utm_source=pypi-{{ project }}&utm_medium=referral&utm_campaign=docs"
+			style="background-color: rgb(246, 145, 77); border-radius: 5px; color: white; display: inline-block; font-family: sans-serif; font-size: 1.2rem; font-weight: bolder; padding: 15px 0; text-align: center; text-decoration: none; text-transform: uppercase; width: 49%;"
+		>Learn more</a>
+		<a
+			href="https://tidelift.com/subscription/request-a-demo?utm_source=pypi-{{ project }}&utm_medium=referral&utm_campaign=docs"
+			style="background-color: rgb(246, 145, 77); border-radius: 5px; color: white; display: inline-block; font-family: sans-serif; font-size: 1.2rem; font-weight: bolder; padding: 15px 0; text-align: center; text-decoration: none; text-transform: uppercase; width: 49%;"
+		>Request a Demo</a>
 	</p>
 <div>


### PR DESCRIPTION
- Limit page width, for better behaviour on tablet/mobile displays.
- Change header level, to better fit usage under main page title header.
- Tweak button font, to actually be sans-serif.
- Tweak button spacing, to fill up as much of the page as reasonable.
- Avoid overspecifying the styling for the elements.
- Reflow markup to be readable without soft wrapping.

All this was noticed while looking at https://setuptools.pypa.io/en/latest/. :)